### PR TITLE
Support Apple M1 on darwin / arm64

### DIFF
--- a/popcount_arm64.go
+++ b/popcount_arm64.go
@@ -6,10 +6,6 @@ import "unsafe"
 
 var usePOPCNT = hasPOPCNT()
 
-func hasPOPCNT() bool {
-	return getProcFeatures()&(0xF<<20) != 15<<20
-}
-
 // CountBytes function counts number of non-zero bits in slice of 8bit unsigned integers.
 func CountBytes(s []byte) uint64 {
 	if len(s) == 0 {

--- a/popcount_arm64_darwin.go
+++ b/popcount_arm64_darwin.go
@@ -1,0 +1,8 @@
+// +build arm64,!gccgo,!appengine,darwin
+
+package popcount
+
+func hasPOPCNT() bool {
+	// We can assume arm64 on darwin means Apple M1 which supports the instruction
+	return true
+}

--- a/popcount_arm64_other.go
+++ b/popcount_arm64_other.go
@@ -1,0 +1,7 @@
+// +build arm64,!gccgo,!appengine,!darwin
+
+package popcount
+
+func hasPOPCNT() bool {
+	return getProcFeatures()&(0xF<<20) != 15<<20
+}


### PR DESCRIPTION
The feature detection causes an illegal instruction on Apple M1:

```
SIGILL: illegal instruction
PC=0x1044d6280 m=0 sigcode=2
instruction bytes: 0x0 0x4 0x38 0xd5 0xe0 0x7 0x0 0xf9 0xc0 0x3 0x5f 0xd6 0x0 0x0 0x0 0x0

goroutine 1 [running, locked to thread]:
github.com/barakmich/go-popcount.getProcFeatures()
	.../Go/go-popcount/popcnt_arm64.s:7 fp=0x1400012dc40 sp=0x1400012dc40 pc=0x1044d6280
github.com/barakmich/go-popcount.hasPOPCNT(...)
	.../Go/go-popcount/popcount_arm64.go:10
github.com/barakmich/go-popcount.init()
	.../Go/go-popcount/popcount_arm64.go:7 +0x20 fp=0x1400012dcf0 sp=0x1400012dc40 pc=0x1044d5e30
runtime.doInit(0x1045cea20)
	/usr/local/go/src/runtime/proc.go:6417 +0x138 fp=0x1400012de30 sp=0x1400012dcf0 pc=0x10442a408
runtime.doInit(0x1045ce6c0)
	/usr/local/go/src/runtime/proc.go:6394 +0x70 fp=0x1400012df70 sp=0x1400012de30 pc=0x10442a340
runtime.main()
	/usr/local/go/src/runtime/proc.go:238 +0x21c fp=0x1400012dfd0 sp=0x1400012df70 pc=0x10441c78c
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1259 +0x4 fp=0x1400012dfd0 sp=0x1400012dfd0 pc=0x104449914
```

I added build tags to always enable the instruction for arm64 on darwin, since we can assume it's an M1 (or compatible) CPU.

The benchmark results (run on Apple M1 Max) are quite impressive: https://gist.github.com/hlubek/86cd6cca0cb4ce18fae5f36a0c1a8795